### PR TITLE
Incorporated Reply schema in Post schema

### DIFF
--- a/src/models/post-model.js
+++ b/src/models/post-model.js
@@ -12,16 +12,14 @@ export const postSchema = new Schema({
     required: true
   },
   author: {
-    type: { type: Schema.Types.ObjectId, ref: 'User' },
-    required: false
+    type: { type: Schema.Types.ObjectId, ref: 'User' }
   },
   date: {
     type: Date,
     default: Date.now
   },
   parent: {
-    type: { type: Schema.Types.ObjectId, ref: 'Post' },
-    required: false
+    type: String
   },
   replies: {
     type: [this],

--- a/src/stores/post-store.js
+++ b/src/stores/post-store.js
@@ -30,7 +30,7 @@ export default function createPostStore(logger) {
         parentPost._doc.replies.push(
           new Post({
             ...reply,
-            parent: parentPost._doc // FIXME: fix parent ref
+            parent: parentPost._doc._id
           })
         );
         return parentPost.save();


### PR DESCRIPTION
Now, `Post` schema replies is an array of Posts. Also, a Post when replied has a parent string attribute referring to the parent `Post` (root or a reply)